### PR TITLE
Fixed bug on creating another pool connection when chaging keys and using transaction

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -33,7 +33,7 @@ var Connection = function () {
 
             if (handle[key].is_pool) {
                 // handle._logger.log('Added a pool connection for', key);
-                connection = _mysql2.default.createPool(handle[key].config);
+                connection = !handle[key].connection ? _mysql2.default.createPool(handle[key].config) : handle[key].connection;
             } else {
                 // handle._logger.log('Created a single connection');
                 connection = _mysql2.default.createConnection(handle[key].config);

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -33,7 +33,7 @@ var Connection = function () {
 
             if (handle[key].is_pool) {
                 // handle._logger.log('Added a pool connection for', key);
-                connection = !handle[key].connection ? _mysql2.default.createPool(handle[key].config) : handle[key].connection;
+                connection = handle[key].connection || _mysql2.default.createPool(handle[key].config);
             } else {
                 // handle._logger.log('Created a single connection');
                 connection = _mysql2.default.createConnection(handle[key].config);

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -18,9 +18,7 @@ export default class Connection {
 
         if (handle[key].is_pool) {
             // handle._logger.log('Added a pool connection for', key);
-            connection = !handle[key].connection
-                       ? mysql.createPool(handle[key].config)
-                       : handle[key].connection;
+            connection = handle[key].connection || mysql.createPool(handle[key].config);
         }
         else {
             // handle._logger.log('Created a single connection');

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -18,7 +18,9 @@ export default class Connection {
 
         if (handle[key].is_pool) {
             // handle._logger.log('Added a pool connection for', key);
-            connection = mysql.createPool(handle[key].config);
+            connection = !handle[key].connection
+                       ? mysql.createPool(handle[key].config)
+                       : handle[key].connection;
         }
         else {
             // handle._logger.log('Created a single connection');


### PR DESCRIPTION
Hello,

I found a bug when using transaction() and pooled connections for example,

```
mysql.use('key1')
         .transaction() // this will create pool 1 for the first time
         .query()
         .commit() 

mysql.use('key2')
          .transaction()  // this will create pool 2 for the first time
          .query()
          .commit()

 // but:
 mysql.use('key1')
          .transaction() // this will again create pool connection same as pool 1
          .query()
          .commit()

```
When you use transaction with interchanging connection keys, chances are it will create many pooled connections.



