### PR TITLE
HD-104089 Earnings > IPN Exception > Miss receiving 250 transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.0.56
+-----
+
+* Fixed a bug where mysql key can be changed since it's using a reference on the mysql object
+
 v0.0.55
 -----
 

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -15,20 +15,19 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var Connection = function () {
-    function Connection(handle) {
+    function Connection(handle, key) {
         _classCallCheck(this, Connection);
 
         this.max_retries = 3;
         this.handle = handle;
         this.retries = 0;
-        this.connect();
+        this.connect(key || handle._key);
     }
 
     _createClass(Connection, [{
         key: 'connect',
-        value: function connect() {
+        value: function connect(key) {
             var handle = this.handle;
-            var key = handle._key;
             var connection = void 0;
 
             if (handle[key].is_pool) {

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -88,7 +88,7 @@ var Query = function () {
                 if (this.mysql[this.key].connection) {
                     this.mysql.current_connection = this.mysql[this.key].connection;
                 } else {
-                    new _Connection2.default(mysql_handler);
+                    new _Connection2.default(mysql_handler, this.key);
                 }
 
                 connection = this.mysql.current_connection;

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -28,7 +28,6 @@ var Query = function () {
 
         this.previous_errors = [];
         this.mysql = mysql;
-        this.connection = mysql.connection;
         this.key = mysql._key;
         this.retryable_errors = this.mysql.retryable_errors || this.mysql[this.key].config.retryable_errors;
         this.retries = 0;

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -28,7 +28,8 @@ var Query = function () {
 
         this.previous_errors = [];
         this.mysql = mysql;
-        this.retryable_errors = this.mysql.retryable_errors || this.mysql[this.mysql._key].config.retryable_errors;
+        this.key = mysql._key;
+        this.retryable_errors = this.mysql.retryable_errors || this.mysql[this.key].config.retryable_errors;
         this.retries = 0;
 
         args.shift();
@@ -84,8 +85,8 @@ var Query = function () {
             }
 
             if (!mysql_handler.current_connection) {
-                if (this.mysql[this.mysql._key].connection) {
-                    this.mysql.current_connection = this.mysql[this.mysql._key].connection;
+                if (this.mysql[this.key].connection) {
+                    this.mysql.current_connection = this.mysql[this.key].connection;
                 } else {
                     new _Connection2.default(mysql_handler);
                 }

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -28,6 +28,7 @@ var Query = function () {
 
         this.previous_errors = [];
         this.mysql = mysql;
+        this.connection = mysql.connection;
         this.key = mysql._key;
         this.retryable_errors = this.mysql.retryable_errors || this.mysql[this.key].config.retryable_errors;
         this.retries = 0;
@@ -84,15 +85,17 @@ var Query = function () {
                 }
             }
 
-            if (!mysql_handler.current_connection) {
+            if (!connection) {
                 if (this.mysql[this.key].connection) {
                     this.mysql.current_connection = this.mysql[this.key].connection;
                 } else {
                     new _Connection2.default(mysql_handler);
                 }
+
+                connection = this.mysql.current_connection;
             }
 
-            mysql_handler.current_connection.query.apply(mysql_handler.current_connection, arguments);
+            connection.query.apply(connection, arguments);
         }
     }]);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anytv-node-mysql",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "description": "Our version of mysql that makes connecting to mysql simpler and more elegant. Especially made for our awesome expressjs boilerplate.",
   "main": "index.js",
   "dependencies": {

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -4,16 +4,15 @@ import mysql from 'mysql';
 
 export default class Connection {
 
-    constructor (handle) {
+    constructor (handle, key) {
         this.max_retries = 3;
         this.handle = handle;
         this.retries = 0;
-        this.connect();
+        this.connect(key || handle._key);
     }
 
-    connect () {
+    connect (key) {
         const handle = this.handle;
-        const key = handle._key;
         let connection;
 
         if (handle[key].is_pool) {

--- a/src/Query.js
+++ b/src/Query.js
@@ -10,7 +10,6 @@ export default class Query {
 
         this.previous_errors = [];
         this.mysql = mysql;
-        this.connection = mysql.connection;
         this.key = mysql._key;
         this.retryable_errors = this.mysql.retryable_errors || this.mysql[this.key].config.retryable_errors;
         this.retries = 0;

--- a/src/Query.js
+++ b/src/Query.js
@@ -10,7 +10,8 @@ export default class Query {
 
         this.previous_errors = [];
         this.mysql = mysql;
-        this.retryable_errors = this.mysql.retryable_errors || this.mysql[this.mysql._key].config.retryable_errors;
+        this.key = mysql._key;
+        this.retryable_errors = this.mysql.retryable_errors || this.mysql[this.key].config.retryable_errors;
         this.retries = 0;
 
         args.shift();
@@ -70,8 +71,8 @@ export default class Query {
 
 
         if (!mysql_handler.current_connection) {
-            if (this.mysql[this.mysql._key].connection) {
-                this.mysql.current_connection = this.mysql[this.mysql._key].connection;
+            if (this.mysql[this.key].connection) {
+                this.mysql.current_connection = this.mysql[this.key].connection;
             }
             else {
                 new Connection(mysql_handler);

--- a/src/Query.js
+++ b/src/Query.js
@@ -10,6 +10,7 @@ export default class Query {
 
         this.previous_errors = [];
         this.mysql = mysql;
+        this.connection = mysql.connection;
         this.key = mysql._key;
         this.retryable_errors = this.mysql.retryable_errors || this.mysql[this.key].config.retryable_errors;
         this.retries = 0;
@@ -70,18 +71,18 @@ export default class Query {
         }
 
 
-        if (!mysql_handler.current_connection) {
+        if (!connection) {
             if (this.mysql[this.key].connection) {
                 this.mysql.current_connection = this.mysql[this.key].connection;
             }
             else {
                 new Connection(mysql_handler);
             }
+
+            connection = this.mysql.current_connection;
         }
 
-        mysql_handler
-            .current_connection
-            .query
-            .apply(mysql_handler.current_connection, arguments);
+        connection.query
+            .apply(connection, arguments);
     }
 }

--- a/src/Query.js
+++ b/src/Query.js
@@ -75,7 +75,7 @@ export default class Query {
                 this.mysql.current_connection = this.mysql[this.key].connection;
             }
             else {
-                new Connection(mysql_handler);
+                new Connection(mysql_handler, this.key);
             }
 
             connection = this.mysql.current_connection;

--- a/test/test.js
+++ b/test/test.js
@@ -1031,8 +1031,7 @@ describe('Overall test', () => {
                     .retry_if(['ER_BAD_NULL_ERROR'])
                     .build('INSERT INTO users (SELECT IF((@tmp := COALESCE(@tmp, 0) + COALESCE(@tmp, 1))=1, NULL, @tmp))')
                     .promise()
-                    .then(() => done())
-                    .catch(err => {
+                    .then(() => {
                         mysql.use(key)
                             .query('DROP TABLE users', done)
                             .end();

--- a/test/test.js
+++ b/test/test.js
@@ -1013,4 +1013,35 @@ describe('Overall test', () => {
         done();
     });
 
+    it ('mysql.query should use the same key when retrying', (done) => {
+        const mysql = new CustomMySQL();
+        const key = 'key';
+        const key2 = 'key2';
+
+        mysql.set_logger(noop_logger)
+            .add(key, FREE_DB)
+            .add(key2, FREE_DB2)
+            .use(key)
+            .query('CREATE TABLE users(id int NOT NULL);', (err, result) => {
+
+                should.equal(err, null);
+                result.should.exist;
+
+                mysql.use(key)
+                    .retry_if(['ER_BAD_NULL_ERROR'])
+                    .build('INSERT INTO users (SELECT IF((@tmp := COALESCE(@tmp, 0) + COALESCE(@tmp, 1))=1, NULL, @tmp))')
+                    .promise()
+                    .then(() => done())
+                    .catch(err => {
+                        mysql.use(key)
+                            .query('DROP TABLE users', done)
+                            .end();
+                    });
+
+                mysql.use(key2);
+            });
+
+
+    });
+
 });


### PR DESCRIPTION
Ticket: https://freedom.myjetbrains.com/youtrack/issue/HD-104089
Changes:
- Locked the key used when Query is constructed instead of using the current key of the mysql handler which can be changed while it is auto-retrying.

Before Testing:
```sql
CREATE DATABASE test;
CREATE DATABASE test2;
```
Test: `npm test`